### PR TITLE
Added a test for CocoaGlk

### DIFF
--- a/Extensions/Victor Gijsbers/Kerkerkruip Start and Finish.i7x
+++ b/Extensions/Victor Gijsbers/Kerkerkruip Start and Finish.i7x
@@ -98,7 +98,7 @@ Include (-
 -).
 
 The detect CocoaGlk rule translates into I6 as "detectCocoaGlk".
-The detect CocoaGlk rule is listed before the virtual machine startup rule in the startup rules.
+The detect CocoaGlk rule is listed first in the Glulx zeroing-reference rulebook.
 
 Section - Detecting whether or not the Gargoyle config file has been applied
 


### PR DESCRIPTION
Per http://inform7.com/mantis/view.php?id=1189#c2425.

The global variable `CocoaGlk detected` might be useful for other things.  For instance, Kerkerkruip's every-turn save is slower under CocoaGlk, so perhaps test builds would want to disable it then.
